### PR TITLE
Versioning github pages when releasing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 .sass-cache/
 .tmp/
 tmp/
-_site/
+_site/*
+!_site/v*
 node_modules/
 bower_components/
 npm-debug.log

--- a/index.js
+++ b/index.js
@@ -96,6 +96,12 @@ function initGHPages(cb){
             '\n').exec('', cb);
 }
 
+function versionGHPage(version){
+    return gulp.src([paths.site['root'] + '/**/*',
+            '!' + paths.site['root'] + '/v**/**'])
+        .pipe(gulp.dest(paths.site['root'] + '/v' + version));
+}
+
 function gulpTasks(globalGulp){
     gulp = globalGulp;
     var packageFilePath = findup('package.json');
@@ -211,7 +217,8 @@ function gulpTasks(globalGulp){
     });
     gulp.task('clean', ['clean:tmp'], function(cb) {
         return del([
-            paths.site['root'],
+            paths.site['root'] + '/*',
+            '!' + paths.site['root'] + '/v*',
             paths.dist['root']
         ], cb);
     });
@@ -337,6 +344,7 @@ function gulpTasks(globalGulp){
         return plugins.bower()
     });
     gulp.task('release:gh-pages', function () {
+        versionGHPage(pkg.version);
         return gulp.src(paths.site['root'] + "/**/*")
             .pipe(plugins['gh-pages']({
                 cacheDir: '.tmp'


### PR DESCRIPTION
Demo: 
[damnhipster.github.io/breadcrumb/v0.1.1](http://damnhipster.github.io/breadcrumb/v0.1.1)

The `.gitignore` file will need to be updated for each component for this to work, since pages for previous versions are stored under `_site/v#.#.#`.

There's a small bug where folders such as `_site/v1.0.0/v0.9.0` get generated, but they're empty and harmless. Couldn't figure out the minimatch pattern to copy files excluding old versions...